### PR TITLE
feat: display info panel after commune selection

### DIFF
--- a/assets/map/rm-map.html
+++ b/assets/map/rm-map.html
@@ -35,6 +35,11 @@
       box-shadow: 0 6px 18px rgba(0,0,0,.10), 0 1px 4px rgba(0,0,0,.06);
       max-width: min(50vw, 420px); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     }
+    #info {
+      position: absolute; top: 15%; left: 20px; z-index: 4;
+      width: 200px; height: 70%; background: #fff; display: none;
+      box-shadow: 0 6px 18px rgba(0,0,0,.10), 0 1px 4px rgba(0,0,0,.06);
+    }
     .hint { font-size: 12px; color: #6b7280; text-align: center; text-shadow: 0 1px 2px rgba(255,255,255,.8); }
   </style>
 </head>
@@ -51,6 +56,7 @@
     </div>
 
     <div id="chip" class="chip">Cargando mapa…</div>
+    <div id="info"></div>
   </div>
 
   <script>
@@ -95,11 +101,16 @@
       map.data.setStyle(styleFeature);
     }
 
+    function showInfo() {
+      document.getElementById('info').style.display = 'block';
+    }
+
     // --- Fit con offset a "2/3 derecha" (configurable) ---
     function fitFeatureWithOffset(feature, {
       padding = { top: 80, right: 20, bottom: 20, left: 20 },
       xRatio = 2/3,   // 0 = borde izq … 0.5 = centro … 1 = borde der
-      yRatio = 0.5    // 0 = arriba … 0.5 = centro … 1 = abajo
+      yRatio = 0.5,   // 0 = arriba … 0.5 = centro … 1 = abajo
+      onDone = null
     } = {}) {
       const bounds = new google.maps.LatLngBounds();
       feature.getGeometry().forEachLatLng(p => bounds.extend(p));
@@ -114,6 +125,9 @@
         const panX = (0.5 - xRatio) * w; // xRatio=2/3 -> panX negativo (centro se mueve hacia la izq, dejando comuna en 2/3 der)
         const panY = (0.5 - yRatio) * h;
         map.panBy(panX, panY);
+        if (typeof onDone === 'function') {
+          google.maps.event.addListenerOnce(map, 'idle', onDone);
+        }
       });
     }
 
@@ -138,7 +152,7 @@
       const hit = idxByName.get(key);
       if (!hit) return;
       highlight(hit.feature);
-      fitFeatureWithOffset(hit.feature, { xRatio: 2/3, yRatio: 0.5 }); // <-- CORREGIDO
+      fitFeatureWithOffset(hit.feature, { xRatio: 2/3, yRatio: 0.5, onDone: showInfo }); // <-- CORREGIDO
       document.getElementById('q').value = hit.name;
       document.getElementById('chip').textContent = hit.name;
       document.getElementById('suggestions').classList.remove('visible');
@@ -168,7 +182,7 @@
       map.data.addListener('mouseout',  e => { document.getElementById('chip').textContent = highlighted ? comunaName(highlighted) : 'Selecciona una comuna'; });
       map.data.addListener('dblclick',  e => {
         highlight(e.feature);
-        fitFeatureWithOffset(e.feature, { xRatio: 2/3, yRatio: 0.5 });   // <-- CORREGIDO
+        fitFeatureWithOffset(e.feature, { xRatio: 2/3, yRatio: 0.5, onDone: showInfo });   // <-- CORREGIDO
         document.getElementById('q').value = comunaName(e.feature);
         document.getElementById('chip').textContent = comunaName(e.feature);
       });


### PR DESCRIPTION
## Summary
- show placeholder info panel after a commune is selected and map zoom completes

## Testing
- `composer lint` *(fails: coding standard errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68be1e6732a88332816b9b90e1c962e2