### PR TITLE
Refactor commune info card layout

### DIFF
--- a/assets/map/rm-map.html
+++ b/assets/map/rm-map.html
@@ -128,7 +128,11 @@
             <span id="info-term-end"></span>
           </div>
         </div>
+        <hr />
         <div id="info-votes"></div>
+        <hr />
+        <div id="info-population"></div>
+        <hr />
         <div id="info-budget"></div>
       </div>
     </div>
@@ -185,6 +189,7 @@
       const termEnd = document.getElementById('info-term-end');
       const termProgress = document.getElementById('info-term-progress');
       const votesEl = document.getElementById('info-votes');
+      const populationEl = document.getElementById('info-population');
       const budgetEl = document.getElementById('info-budget');
 
       if (headerName) headerName.textContent = name;
@@ -194,6 +199,7 @@
       if (termEnd) termEnd.textContent = '';
       if (termProgress) termProgress.style.width = '0%';
       if (votesEl) votesEl.textContent = '';
+      if (populationEl) populationEl.textContent = '';
       if (budgetEl) budgetEl.textContent = '';
 
       try {
@@ -220,6 +226,9 @@
             }
             if (votesEl && data.votes !== null && data.votes !== undefined) {
               votesEl.textContent = `${Number(data.votes).toLocaleString('es-CL')} votos`;
+            }
+            if (populationEl && data.population !== null && data.population !== undefined) {
+              populationEl.textContent = `Población: ${Number(data.population).toLocaleString('es-CL')}`;
             }
             if (budgetEl && data.budget !== null && data.budget !== undefined) {
               budgetEl.textContent = `Presupuesto Anual Municipal: $${Number(data.budget).toLocaleString('es-CL')}`;

--- a/assets/map/rm-map.html
+++ b/assets/map/rm-map.html
@@ -36,21 +36,30 @@
       max-width: min(50vw, 420px); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     }
 
-    /* Panel de información (350px x 70% alto) */
+    /* Panel de información (350px width, auto height) */
     #comune-info-card {
       position: absolute; top: 15%; left: 20px; z-index: 4;
-      width: 350px; height: 70%; background: #fff; display: none;
+      width: 350px; background: #fff; display: none;
       box-shadow: 0 6px 18px rgba(0,0,0,.10), 0 1px 4px rgba(0,0,0,.06);
-      border-radius: 10px;
+      border-radius: 10px; overflow: hidden;
     }
-    #comune-info-card h2 {
-      margin: 0; padding: 10px 12px; font-size: 18px; text-align: left;
-    }
-
-    #comune-info-card .content {
-      padding: 0 12px 12px;
+    #INFOCARD-HEADER, #INFOCARD-COMMUNE {
+      padding: 10px 12px;
       font-size: 14px;
       line-height: 1.4;
+    }
+    #INFOCARD-HEADER {
+      border-bottom: 1px solid rgba(0,0,0,.1);
+    }
+    #info-mayor-photo {
+      width: 80px; height: 80px; border-radius: 50%; object-fit: cover;
+      display: none;
+    }
+    #info-term-bar {
+      width: 100%; height: 6px; background: #e5e7eb; border-radius: 4px; overflow: hidden; margin: 4px 0;
+    }
+    #info-term-progress {
+      height: 100%; background: #3b82f6; width: 0%;
     }
 
     .hint { font-size: 12px; color: #6b7280; text-align: center; text-shadow: 0 1px 2px rgba(255,255,255,.8); }
@@ -69,7 +78,28 @@
     </div>
 
     <div id="chip" class="chip">Cargando mapa…</div>
-    <div id="comune-info-card"><h2></h2><hr /><div class="content"></div></div>
+    <div id="comune-info-card">
+      <div id="INFOCARD-HEADER">
+        <div id="info-header-type">Comuna</div>
+        <div id="info-header-name"></div>
+        <div id="info-header-official"></div>
+      </div>
+      <div id="INFOCARD-COMMUNE">
+        <img id="info-mayor-photo" alt="" />
+        <div id="info-mayor-name"></div>
+        <div id="info-office-party"></div>
+        <div id="info-term">
+          <div id="info-term-label">PERÍODO</div>
+          <div id="info-term-bar"><div id="info-term-progress"></div></div>
+          <div id="info-term-dates">
+            <span id="info-term-start"></span>
+            <span id="info-term-end"></span>
+          </div>
+        </div>
+        <div id="info-votes"></div>
+        <div id="info-budget"></div>
+      </div>
+    </div>
   </div>
 
   <script>
@@ -116,31 +146,75 @@
 
     async function showInfo(name) {
       const box = document.getElementById('comune-info-card');
-      const h2 = box.querySelector('h2');
-      if (h2 && name) h2.textContent = name.toUpperCase();
+      const headerName = document.getElementById('info-header-name');
+      const headerOfficial = document.getElementById('info-header-official');
+      const mayorPhoto = document.getElementById('info-mayor-photo');
+      const mayorName = document.getElementById('info-mayor-name');
+      const officeParty = document.getElementById('info-office-party');
+      const termStart = document.getElementById('info-term-start');
+      const termEnd = document.getElementById('info-term-end');
+      const termProgress = document.getElementById('info-term-progress');
+      const votesEl = document.getElementById('info-votes');
+      const budgetEl = document.getElementById('info-budget');
 
-      const content = box.querySelector('.content');
-      if (content) {
-        content.innerHTML = '';
-        try {
-          const res = await fetch(`/wp-json/politeia/v1/jurisdictions?name=${encodeURIComponent(name)}`);
-          if (res.ok) {
-            const data = await res.json();
-            if (data.found && data.person_name) {
-              content.innerHTML = `
-                <div>${data.person_name}</div>
-                <div>${data.office_title || ''}</div>
-                ${data.started_on ? `<div>Desde ${data.started_on}</div>` : ''}`;
-            } else {
-              content.innerHTML = '<div>No hay datos disponibles.</div>';
+      if (headerName) headerName.textContent = name;
+      if (headerOfficial) headerOfficial.textContent = '';
+      if (mayorPhoto) { mayorPhoto.style.display = 'none'; mayorPhoto.src = ''; }
+      if (mayorName) mayorName.textContent = '';
+      if (officeParty) officeParty.textContent = '';
+      if (termStart) termStart.textContent = '';
+      if (termEnd) termEnd.textContent = '';
+      if (termProgress) termProgress.style.width = '0%';
+      if (votesEl) votesEl.textContent = '';
+      if (budgetEl) budgetEl.textContent = '';
+
+      try {
+        const res = await fetch(`/wp-json/politeia/v1/jurisdictions?name=${encodeURIComponent(name)}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.found) {
+            if (headerName && data.common_name) headerName.textContent = data.common_name;
+            if (headerOfficial) headerOfficial.textContent = data.jurisdiction_name || '';
+            if (mayorPhoto) {
+              if (data.photo_url) {
+                mayorPhoto.src = data.photo_url;
+                mayorPhoto.style.display = 'block';
+              } else {
+                mayorPhoto.style.display = 'none';
+              }
             }
-          } else {
-            content.innerHTML = '<div>Error al cargar datos.</div>';
+            if (mayorName) mayorName.textContent = data.person_name || '';
+            if (officeParty) {
+              const parts = [];
+              if (data.office_title) parts.push(data.office_title);
+              if (data.party_short_name) parts.push(data.party_short_name);
+              officeParty.textContent = parts.join(', ');
+            }
+            if (termStart) termStart.textContent = data.started_on || '';
+            if (termEnd) termEnd.textContent = data.planned_end_on || '';
+            if (termProgress && data.started_on && data.planned_end_on) {
+              const start = new Date(data.started_on);
+              const end = new Date(data.planned_end_on);
+              const now = new Date();
+              const ratio = Math.min(Math.max((now - start) / (end - start), 0), 1);
+              termProgress.style.width = (ratio * 100) + '%';
+            }
+            if (votesEl && data.votes !== null && data.votes !== undefined) {
+              votesEl.textContent = `${Number(data.votes).toLocaleString('es-CL')} votos`;
+            }
+            if (budgetEl && data.budget !== null && data.budget !== undefined) {
+              budgetEl.textContent = `Presupuesto Anual Municipal: $${Number(data.budget).toLocaleString('es-CL')}`;
+            }
+          } else if (mayorName) {
+            mayorName.textContent = 'No hay datos disponibles.';
           }
-        } catch (e) {
-          content.innerHTML = '<div>Error al cargar datos.</div>';
+        } else if (mayorName) {
+          mayorName.textContent = 'Error al cargar datos.';
         }
+      } catch (e) {
+        if (mayorName) mayorName.textContent = 'Error al cargar datos.';
       }
+
       box.style.display = 'block';
     }
 

--- a/assets/map/rm-map.html
+++ b/assets/map/rm-map.html
@@ -59,7 +59,7 @@
       margin-bottom: 20px;
     }
     #info-mayor-photo {
-      width: 80px;
+      width: 94px;
       height: 80px;
       border-radius: 50%;
       background: #d1d5db;
@@ -89,6 +89,8 @@
     }
     #info-mayor-name {
       font-size: 20px;
+      font-weight: 700;
+      line-height: 1;
     }
 
     .hint { font-size: 12px; color: #6b7280; text-align: center; text-shadow: 0 1px 2px rgba(255,255,255,.8); }
@@ -143,6 +145,10 @@
     const params = new URLSearchParams(location.search);
     const API_KEY = params.get('api_key') || '';
     const GEOJSON_URL = '../geojson/comunas_rm_oficial_wgs84.geojson';
+    const { __, sprintf } = window.wp?.i18n || {
+      __: s => s,
+      sprintf: (s, ...a) => s.replace(/%s/g, () => a.shift())
+    };
 
     // --- Estado ---
     let map, highlighted = null;
@@ -225,10 +231,16 @@
               termProgress.style.width = (ratio * 100) + '%';
             }
             if (votesEl && data.votes !== null && data.votes !== undefined) {
-              votesEl.textContent = `${Number(data.votes).toLocaleString('es-CL')} votos`;
+              votesEl.textContent = sprintf(
+                __('Votes: %s', 'politeia-electoral-map'),
+                Number(data.votes).toLocaleString('es-CL')
+              );
             }
             if (populationEl && data.population !== null && data.population !== undefined) {
-              populationEl.textContent = `Población: ${Number(data.population).toLocaleString('es-CL')}`;
+              populationEl.textContent = sprintf(
+                __('Population: %s', 'politeia-electoral-map'),
+                Number(data.population).toLocaleString('es-CL')
+              );
             }
             if (budgetEl && data.budget !== null && data.budget !== undefined) {
               budgetEl.textContent = `Presupuesto Anual Municipal: $${Number(data.budget).toLocaleString('es-CL')}`;

--- a/assets/map/rm-map.html
+++ b/assets/map/rm-map.html
@@ -44,7 +44,7 @@
       border-radius: 10px; overflow: hidden;
     }
     #INFOCARD-HEADER, #INFOCARD-COMMUNE {
-      padding: 10px 12px;
+      padding: 20px;
       font-size: 14px;
       line-height: 1.4;
     }
@@ -56,7 +56,7 @@
       align-items: center;
       justify-content: center;
       gap: 12px;
-      margin-bottom: 8px;
+      margin-bottom: 20px;
     }
     #info-mayor-photo {
       width: 80px;
@@ -72,10 +72,16 @@
     }
     #info-term {
       text-align: center;
+      margin-bottom: 20px;
     }
     #info-term-dates {
       display: flex;
       justify-content: space-between;
+      font-size: 10px;
+    }
+    #info-term-label {
+      font-size: 10px;
+      letter-spacing: 4px;
     }
     #info-header-name {
       font-size: 28px;
@@ -105,7 +111,6 @@
       <div id="INFOCARD-HEADER">
         <div id="info-header-type">Comuna</div>
         <div id="info-header-name"></div>
-        <div id="info-header-official"></div>
       </div>
       <div id="INFOCARD-COMMUNE">
         <div id="info-mayor">
@@ -174,7 +179,6 @@
     async function showInfo(name) {
       const box = document.getElementById('comune-info-card');
       const headerName = document.getElementById('info-header-name');
-      const headerOfficial = document.getElementById('info-header-official');
       const mayorName = document.getElementById('info-mayor-name');
       const officeParty = document.getElementById('info-office-party');
       const termStart = document.getElementById('info-term-start');
@@ -184,7 +188,6 @@
       const budgetEl = document.getElementById('info-budget');
 
       if (headerName) headerName.textContent = name;
-      if (headerOfficial) headerOfficial.textContent = '';
       if (mayorName) mayorName.textContent = '';
       if (officeParty) officeParty.textContent = '';
       if (termStart) termStart.textContent = '';
@@ -199,7 +202,6 @@
           const data = await res.json();
           if (data.found) {
             if (headerName && data.common_name) headerName.textContent = data.common_name;
-            if (headerOfficial) headerOfficial.textContent = data.jurisdiction_name || '';
             if (mayorName) mayorName.textContent = data.person_name || '';
             if (officeParty) {
               const parts = [];

--- a/assets/map/rm-map.html
+++ b/assets/map/rm-map.html
@@ -51,15 +51,38 @@
     #INFOCARD-HEADER {
       border-bottom: 1px solid rgba(0,0,0,.1);
     }
+    #info-mayor {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      margin-bottom: 8px;
+    }
     #info-mayor-photo {
-      width: 80px; height: 80px; border-radius: 50%; object-fit: cover;
-      display: none;
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+      background: #d1d5db;
     }
     #info-term-bar {
       width: 100%; height: 6px; background: #e5e7eb; border-radius: 4px; overflow: hidden; margin: 4px 0;
     }
     #info-term-progress {
       height: 100%; background: #3b82f6; width: 0%;
+    }
+    #info-term {
+      text-align: center;
+    }
+    #info-term-dates {
+      display: flex;
+      justify-content: space-between;
+    }
+    #info-header-name {
+      font-size: 28px;
+      font-weight: 700;
+    }
+    #info-mayor-name {
+      font-size: 20px;
     }
 
     .hint { font-size: 12px; color: #6b7280; text-align: center; text-shadow: 0 1px 2px rgba(255,255,255,.8); }
@@ -85,9 +108,13 @@
         <div id="info-header-official"></div>
       </div>
       <div id="INFOCARD-COMMUNE">
-        <img id="info-mayor-photo" alt="" />
-        <div id="info-mayor-name"></div>
-        <div id="info-office-party"></div>
+        <div id="info-mayor">
+          <div id="info-mayor-photo"></div>
+          <div id="info-mayor-details">
+            <div id="info-mayor-name"></div>
+            <div id="info-office-party"></div>
+          </div>
+        </div>
         <div id="info-term">
           <div id="info-term-label">PERÍODO</div>
           <div id="info-term-bar"><div id="info-term-progress"></div></div>
@@ -148,7 +175,6 @@
       const box = document.getElementById('comune-info-card');
       const headerName = document.getElementById('info-header-name');
       const headerOfficial = document.getElementById('info-header-official');
-      const mayorPhoto = document.getElementById('info-mayor-photo');
       const mayorName = document.getElementById('info-mayor-name');
       const officeParty = document.getElementById('info-office-party');
       const termStart = document.getElementById('info-term-start');
@@ -159,7 +185,6 @@
 
       if (headerName) headerName.textContent = name;
       if (headerOfficial) headerOfficial.textContent = '';
-      if (mayorPhoto) { mayorPhoto.style.display = 'none'; mayorPhoto.src = ''; }
       if (mayorName) mayorName.textContent = '';
       if (officeParty) officeParty.textContent = '';
       if (termStart) termStart.textContent = '';
@@ -175,14 +200,6 @@
           if (data.found) {
             if (headerName && data.common_name) headerName.textContent = data.common_name;
             if (headerOfficial) headerOfficial.textContent = data.jurisdiction_name || '';
-            if (mayorPhoto) {
-              if (data.photo_url) {
-                mayorPhoto.src = data.photo_url;
-                mayorPhoto.style.display = 'block';
-              } else {
-                mayorPhoto.style.display = 'none';
-              }
-            }
             if (mayorName) mayorName.textContent = data.person_name || '';
             if (officeParty) {
               const parts = [];

--- a/includes/Modules/REST/class-jurisdictions.php
+++ b/includes/Modules/REST/class-jurisdictions.php
@@ -48,34 +48,52 @@ class Jurisdictions extends Controller {
 			return new WP_REST_Response( array( 'found' => false ), 200 );
 		}
 
-		$jurisdictions = $wpdb->prefix . 'politeia_jurisdictions';
-		$terms         = $wpdb->prefix . 'politeia_office_terms';
-		$people        = $wpdb->prefix . 'politeia_people';
-		$offices       = $wpdb->prefix . 'politeia_offices';
+				$jurisdictions     = $wpdb->prefix . 'politeia_jurisdictions';
+				$terms             = $wpdb->prefix . 'politeia_office_terms';
+				$people            = $wpdb->prefix . 'politeia_people';
+				$offices           = $wpdb->prefix . 'politeia_offices';
+				$party_memberships = $wpdb->prefix . 'politeia_party_memberships';
+				$parties           = $wpdb->prefix . 'politeia_political_parties';
+				$budgets           = $wpdb->prefix . 'politeia_jurisdiction_budgets';
+				$elections         = $wpdb->prefix . 'politeia_elections';
+				$candidacies       = $wpdb->prefix . 'politeia_candidacies';
 
         /* phpcs:disable WordPress.DB.PreparedSQL.NotPrepared */
-		$query = "SELECT j.official_name AS jurisdiction_name,
+				$query = "SELECT j.official_name AS jurisdiction_name,
+                    j.common_name AS common_name,
                     CONCAT_WS(' ', p.given_names, p.paternal_surname, p.maternal_surname) AS person_name,
+                    p.photo_url,
                     o.title AS office_title,
-                    t.started_on
+                    pa.short_name AS party_short_name,
+                    t.started_on,
+                    t.planned_end_on,
+                    (SELECT c.votes FROM %s c INNER JOIN %s e ON e.id = c.election_id WHERE c.person_id = t.person_id AND e.jurisdiction_id = j.id AND e.office_id = t.office_id ORDER BY e.election_date DESC LIMIT 1) AS votes,
+                    (SELECT b.amount_total FROM %s b WHERE b.jurisdiction_id = j.id ORDER BY b.fiscal_year DESC LIMIT 1) AS budget
              FROM %s j
              LEFT JOIN %s t ON t.jurisdiction_id = j.id AND t.ended_on IS NULL
              LEFT JOIN %s p ON p.id = t.person_id
              LEFT JOIN %s o ON o.id = t.office_id
+             LEFT JOIN %s pm ON pm.person_id = p.id AND pm.ended_on IS NULL
+             LEFT JOIN %s pa ON pa.id = pm.party_id
              WHERE j.official_name = %%s OR j.common_name = %%s
              LIMIT 1";
 
-		$sql = $wpdb->prepare(
-			sprintf(
-				$query,
-				$jurisdictions,
-				$terms,
-				$people,
-				$offices
-			),
-			$name,
-			$name
-		);
+				$sql = $wpdb->prepare(
+					sprintf(
+						$query,
+						$candidacies,
+						$elections,
+						$budgets,
+						$jurisdictions,
+						$terms,
+						$people,
+						$offices,
+						$party_memberships,
+						$parties
+					),
+					$name,
+					$name
+				);
         /* phpcs:enable */
 
 		$row = $wpdb->get_row( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
@@ -83,16 +101,22 @@ class Jurisdictions extends Controller {
 			return new WP_REST_Response( array( 'found' => false ), 200 );
 		}
 
-		return new WP_REST_Response(
-			array(
-				'found'             => true,
-				'jurisdiction_name' => $row['jurisdiction_name'],
-				'person_name'       => trim( $row['person_name'] ),
-				'office_title'      => $row['office_title'],
-				'started_on'        => $row['started_on'],
-			),
-			200
-		);
+				return new WP_REST_Response(
+					array(
+						'found'             => true,
+						'jurisdiction_name' => $row['jurisdiction_name'],
+						'common_name'       => $row['common_name'],
+						'person_name'       => trim( $row['person_name'] ),
+						'photo_url'         => $row['photo_url'],
+						'office_title'      => $row['office_title'],
+						'party_short_name'  => $row['party_short_name'],
+						'started_on'        => $row['started_on'],
+						'planned_end_on'    => $row['planned_end_on'],
+						'votes'             => $row['votes'],
+						'budget'            => $row['budget'],
+					),
+					200
+				);
 	}
 }
 

--- a/includes/Modules/REST/class-jurisdictions.php
+++ b/includes/Modules/REST/class-jurisdictions.php
@@ -48,15 +48,16 @@ class Jurisdictions extends Controller {
 			return new WP_REST_Response( array( 'found' => false ), 200 );
 		}
 
-				$jurisdictions     = $wpdb->prefix . 'politeia_jurisdictions';
-				$terms             = $wpdb->prefix . 'politeia_office_terms';
-				$people            = $wpdb->prefix . 'politeia_people';
-				$offices           = $wpdb->prefix . 'politeia_offices';
-				$party_memberships = $wpdb->prefix . 'politeia_party_memberships';
-				$parties           = $wpdb->prefix . 'politeia_political_parties';
-				$budgets           = $wpdb->prefix . 'politeia_jurisdiction_budgets';
-				$elections         = $wpdb->prefix . 'politeia_elections';
-				$candidacies       = $wpdb->prefix . 'politeia_candidacies';
+		$jurisdictions     = $wpdb->prefix . 'politeia_jurisdictions';
+		$terms             = $wpdb->prefix . 'politeia_office_terms';
+		$people            = $wpdb->prefix . 'politeia_people';
+		$offices           = $wpdb->prefix . 'politeia_offices';
+		$party_memberships = $wpdb->prefix . 'politeia_party_memberships';
+		$parties           = $wpdb->prefix . 'politeia_political_parties';
+		$budgets           = $wpdb->prefix . 'politeia_jurisdiction_budgets';
+		$populations       = $wpdb->prefix . 'politeia_jurisdiction_populations';
+		$elections         = $wpdb->prefix . 'politeia_elections';
+		$candidacies       = $wpdb->prefix . 'politeia_candidacies';
 
         /* phpcs:disable WordPress.DB.PreparedSQL.NotPrepared */
 				$query = "SELECT j.official_name AS jurisdiction_name,
@@ -68,7 +69,8 @@ class Jurisdictions extends Controller {
                     t.started_on,
                     t.planned_end_on,
                     (SELECT c.votes FROM %s c INNER JOIN %s e ON e.id = c.election_id WHERE c.person_id = t.person_id AND e.jurisdiction_id = j.id AND e.office_id = t.office_id ORDER BY e.election_date DESC LIMIT 1) AS votes,
-                    (SELECT b.amount_total FROM %s b WHERE b.jurisdiction_id = j.id ORDER BY b.fiscal_year DESC LIMIT 1) AS budget
+                    (SELECT b.amount_total FROM %s b WHERE b.jurisdiction_id = j.id ORDER BY b.fiscal_year DESC LIMIT 1) AS budget,
+                    (SELECT pop.population FROM %s pop WHERE pop.jurisdiction_id = j.id ORDER BY pop.year DESC LIMIT 1) AS population
              FROM %s j
              LEFT JOIN %s t ON t.jurisdiction_id = j.id AND t.ended_on IS NULL
              LEFT JOIN %s p ON p.id = t.person_id
@@ -84,6 +86,7 @@ class Jurisdictions extends Controller {
 						$candidacies,
 						$elections,
 						$budgets,
+						$populations,
 						$jurisdictions,
 						$terms,
 						$people,
@@ -113,6 +116,7 @@ class Jurisdictions extends Controller {
 						'started_on'        => $row['started_on'],
 						'planned_end_on'    => $row['planned_end_on'],
 						'votes'             => $row['votes'],
+						'population'        => $row['population'],
 						'budget'            => $row['budget'],
 					),
 					200


### PR DESCRIPTION
## Summary
- redesign commune info card into header and commune sections with element IDs for custom styling
- expand frontend card to show mayor info, term progress, votes, and budget from REST endpoint
- update jurisdictions REST query to return party, term end, votes, budget, and photo data

## Testing
- `composer lint` *(fails: Script vendor/bin/phpcs --standard=phpcs.xml.dist --extensions=php,inc --ignore=vendor . handling the lint event returned with error code 2)*
- `vendor/bin/phpcs --standard=phpcs.xml.dist includes/Modules/REST/class-jurisdictions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf7b8dc8548332b09c984132d25282