### PR TITLE
Adjust session styling and remove redundant title

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,0 +1,4 @@
+.prs-session-id {
+    font-size: 10px !important;
+    letter-spacing: 2px;
+}

--- a/assets/map/rm-map.html
+++ b/assets/map/rm-map.html
@@ -358,6 +358,13 @@
       document.addEventListener('click', e => { if (!e.target.closest('.toolbar')) box.classList.remove('visible'); });
     };
 
+    document.addEventListener('DOMContentLoaded', () => {
+      const redundantTitle = document.querySelector('.prs-session-modal__content .prs-book-title');
+      if (redundantTitle) {
+        redundantTitle.remove();
+      }
+    });
+
     if (API_KEY) {
       const s = document.createElement('script');
       s.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(API_KEY)}&callback=initMap`;


### PR DESCRIPTION
## Summary
- update the `.prs-session-id` rule to use the requested font size and letter spacing
- strip the redundant book title from the session modal content at runtime

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690736da1dd08332a7e5e6b3852e6692